### PR TITLE
Adding a bug fix to train and infer model as tokenizer.convert_tokens _to_string expects list[strings] instead of strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ see `README_tokenizer.md` for further information.
 #### Simple use
 
 ```python
-from convlm.tokenizer import SpokenDialogTokenizer
+from turngpt.tokenizer  import SpokenDialogTokenizer
 
 pretrained_model_name_or_path="microsoft/DialoGPT-small"
 tokenizer = SpokenDialogTokenizer(pretrained_model_name_or_path)
@@ -110,7 +110,7 @@ An un-trained TurnGPT model, loads pre-trained weights by default, and includes 
 
 ```python
   from argparse import ArgumentParser
-  from convlm.turngpt import TurnGPT
+  from turngpt import TurnGPT
 
   parser = ArgumentParser()
   parser = TurnGPT.add_model_specific_args(parser)

--- a/turngpt/model.py
+++ b/turngpt/model.py
@@ -68,7 +68,7 @@ class Utils:
             idx = idx.item()
         s = self.tokenizer.convert_ids_to_tokens(idx)
         s = self.tokenizer.convert_tokens_to_string(
-            s.strip()
+            [s.strip()]
         )  # remove prefix space/symbol
         return s
 

--- a/turngpt/train.py
+++ b/turngpt/train.py
@@ -6,7 +6,7 @@ from pytorch_lightning.callbacks import ModelCheckpoint, EarlyStopping
 
 import pytorch_lightning as pl
 
-from datasets_turntaking import DialogTextDM
+from datasets_turntaking import ConversationalDM as DialogTextDM
 from turngpt.model import TurnGPT, TurnGPTWandbCallbacks
 
 


### PR DESCRIPTION
Changes in the PR

1)Replacing imports in readme to use `from turngpt` instead of `from convlm.turngpt` as convlm is not a package that exists in current repo.
2) the transformers  [ tokenizer.convert_tokens_to_string ](https://github.com/huggingface/transformers/blob/main/src/transformers/tokenization_utils.py#L988) function takes in list[strings] instead of a string so casting the argument to list<string> before passing.
3)Fix a import statement in train.py occurred due to renaming of DialogTextDM to ConversationalDM in datasets_turntaking.